### PR TITLE
Add dedicated income category

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,21 @@ const seededTransaction = (
 
 const initialCategories: Category[] = [
   {
+    id: 'income',
+    name: 'Income',
+    accent: '#34d399',
+    description: 'Your primary paycheck or recurring income stream to anchor the plan.',
+    transactions: [
+      seededTransaction({
+        label: 'Primary paycheck',
+        amount: 3200,
+        cadence: 'Monthly',
+        flow: 'Income',
+        note: 'Lands near the first of each month'
+      })
+    ]
+  },
+  {
     id: 'financial-obligations',
     name: 'Financial obligations',
     accent: '#38bdf8',
@@ -157,6 +172,7 @@ export default function App() {
 
   const categoryMonthlyTotals = useMemo(() => {
     const totals: Record<CategoryKey, number> = {
+      income: 0,
       'financial-obligations': 0,
       'lifestyle-recurring': 0,
       'personal-family': 0,

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import {
   CategoryKey,
   TransactionCadence,
@@ -29,10 +29,10 @@ interface TransactionFormProps {
 }
 
 export function TransactionForm({ categories, onAddTransaction }: TransactionFormProps) {
-  const initialCategory = useMemo(
-    () => categories[0]?.id ?? 'financial-obligations',
-    [categories]
-  );
+  const initialCategory = useMemo(() => {
+    const firstNonIncome = categories.find((category) => category.id !== 'income');
+    return firstNonIncome?.id ?? categories[0]?.id ?? 'financial-obligations';
+  }, [categories]);
 
   const [label, setLabel] = useState('');
   const [amount, setAmount] = useState('');
@@ -48,6 +48,17 @@ export function TransactionForm({ categories, onAddTransaction }: TransactionFor
     setFlow('Expense');
     setNote('');
   };
+
+  useEffect(() => {
+    setCategoryId((current) => {
+      const exists = categories.some((category) => category.id === current);
+      if (exists) {
+        return current;
+      }
+
+      return initialCategory;
+    });
+  }, [categories, initialCategory]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type CategoryKey =
+  | 'income'
   | 'financial-obligations'
   | 'lifestyle-recurring'
   | 'personal-family'


### PR DESCRIPTION
## Summary
- add a seeded income category so recurring pay can be tracked alongside expenses
- extend monthly total calculations to recognize the income category key
- keep the transaction form defaulting to an expense category when new categories are introduced

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dca0285168832f9e06fc66f6c42a9f