### PR TITLE
Update landing type definitions for Google credential callback

### DIFF
--- a/src/landing.d.ts
+++ b/src/landing.d.ts
@@ -1,0 +1,23 @@
+import type { FC } from 'react';
+
+export interface LandingThemeOverrides {
+  [token: string]: string | undefined;
+}
+
+export interface LandingProps {
+  /**
+   * Customize the color tokens used by the landing experience.
+   * Provide a map of token name to color value (CSS color string).
+   */
+  theme?: LandingThemeOverrides;
+  /**
+   * Optional overrides applied when rendering in dark mode.
+   */
+  themeDark?: LandingThemeOverrides;
+  /**
+   * Handler invoked when the Google Identity Services widget returns a credential response.
+   */
+  onGoogleCredential: (credential: string) => void;
+}
+
+export declare const Landing: FC<LandingProps>;


### PR DESCRIPTION
## Summary
- add a landing.d.ts type definition to expose the LandingProps interface
- include theme override support and a required onGoogleCredential handler on the props
- export the Landing component signature using the revised props interface

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e73bfcfb10832fa8186d3a5fd3d86f