### PR TITLE
Connect app to Supabase REST endpoints

### DIFF
--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -25,7 +25,7 @@ interface TransactionFormProps {
     cadence: TransactionCadence;
     flow: TransactionFlow;
     note: string;
-  }) => void;
+  }) => Promise<void> | void;
 }
 
 export function TransactionForm({ categories, onAddTransaction }: TransactionFormProps) {
@@ -60,7 +60,7 @@ export function TransactionForm({ categories, onAddTransaction }: TransactionFor
     });
   }, [categories, initialCategory]);
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const parsedAmount = Number(amount);
 
@@ -68,7 +68,7 @@ export function TransactionForm({ categories, onAddTransaction }: TransactionFor
       return;
     }
 
-    onAddTransaction({
+    await onAddTransaction({
       categoryId,
       label: label.trim(),
       amount: parsedAmount,

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,117 @@
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.warn('Supabase environment variables are not defined.');
+}
+
+type SupabaseResponse<T> = {
+  data: T | null;
+  error: Error | null;
+};
+
+const baseHeaders: HeadersInit = {
+  apikey: supabaseKey ?? '',
+  Authorization: `Bearer ${supabaseKey ?? ''}`,
+  'Content-Type': 'application/json'
+};
+
+function missingConfigResponse<T>(): SupabaseResponse<T> {
+  return {
+    data: null,
+    error: new Error('Supabase environment variables are not defined.')
+  };
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<SupabaseResponse<T>> {
+  if (!supabaseUrl || !supabaseKey) {
+    return missingConfigResponse<T>();
+  }
+  try {
+    const response = await fetch(url, {
+      ...init,
+      headers: {
+        ...baseHeaders,
+        ...(init?.headers ?? {})
+      }
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return { data: null, error: new Error(errorText || response.statusText) };
+    }
+
+    if (response.status === 204) {
+      return { data: null, error: null };
+    }
+
+    const json = (await response.json()) as T;
+    return { data: json, error: null };
+  } catch (error) {
+    return { data: null, error: error as Error };
+  }
+}
+
+export async function fetchCategories() {
+  if (!supabaseUrl) {
+    return missingConfigResponse();
+  }
+  const url = `${supabaseUrl}/rest/v1/categories?select=*&order=sort_order`;
+  return fetchJson(url);
+}
+
+export async function fetchTransactions() {
+  if (!supabaseUrl) {
+    return missingConfigResponse();
+  }
+  const url = `${supabaseUrl}/rest/v1/transactions?select=*`;
+  return fetchJson(url);
+}
+
+export async function insertTransaction(payload: {
+  category_id: string;
+  label: string;
+  amount: number;
+  cadence: string;
+  flow: string;
+  note: string;
+}) {
+  if (!supabaseUrl) {
+    return missingConfigResponse();
+  }
+  const url = `${supabaseUrl}/rest/v1/transactions`;
+  return fetchJson(url, {
+    method: 'POST',
+    headers: {
+      Prefer: 'return=representation'
+    },
+    body: JSON.stringify(payload)
+  });
+}
+
+export async function updateTransactionCategory(transactionId: string, toCategory: string) {
+  if (!supabaseUrl) {
+    return missingConfigResponse();
+  }
+  const url = `${supabaseUrl}/rest/v1/transactions?id=eq.${transactionId}`;
+  return fetchJson(url, {
+    method: 'PATCH',
+    headers: {
+      Prefer: 'return=minimal'
+    },
+    body: JSON.stringify({ category_id: toCategory })
+  });
+}
+
+export async function deleteTransactionById(transactionId: string) {
+  if (!supabaseUrl) {
+    return missingConfigResponse();
+  }
+  const url = `${supabaseUrl}/rest/v1/transactions?id=eq.${transactionId}`;
+  return fetchJson(url, {
+    method: 'DELETE',
+    headers: {
+      Prefer: 'return=minimal'
+    }
+  });
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- remove the hard-coded seed data and load categories and transactions from Supabase REST endpoints
- persist creates, moves, and deletes through REST helpers with optimistic updates in local state
- allow async transaction submission and add a loading state while remote data is fetched

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e86f70d3cc832fada254975f2e2198