### PR TITLE
Support configuring Google client IDs per host

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,17 @@ npm run dev
 ### Enabling Google sign-in
 
 1. In the Google Cloud Console, enable **Google Identity Services** and create a Web OAuth client ID.
-2. Either set `VITE_GOOGLE_CLIENT_ID` in a `.env` file at the project root or open `src/config/googleClient.ts` and paste the same client ID into the exported `GOOGLE_CLIENT_ID` string.
+2. Either set `VITE_GOOGLE_CLIENT_ID` in a `.env` file at the project root or update `src/config/googleClient.ts` with a hostname entry that maps to the client ID.
 3. Restart the dev server so Vite can pick up the value. Once the ID is present, the landing page will render the Google sign-in button and forward the credential back to the app.
+
+### Deploying with Google sign-in
+
+When deploying to Netlify (or any other host), create a separate OAuth client ID in the Google Cloud Console and add the deployed domain under **Authorized JavaScript origins**. Then provide the client ID to the app in one of two ways:
+
+- Set a Netlify environment variable named `VITE_GOOGLE_CLIENT_ID` with the production client ID.
+- Or, set `VITE_GOOGLE_CLIENT_ID_MAP` to a JSON object such as `{ "your-site.netlify.app": "oauth-client-id.apps.googleusercontent.com" }` so the app automatically selects the right ID based on `window.location.host`.
+
+Without this configuration Google will respond with an `origin_mismatch` error when users try to sign in from the deployed site.
 
 ## Features
 

--- a/ini.env
+++ b/ini.env
@@ -1,2 +1,5 @@
 VITE_SUPABASE_URL=https://your-project-ref.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_GOOGLE_CLIENT_ID=
+# Or provide a hostname -> client ID mapping for deployments
+# VITE_GOOGLE_CLIENT_ID_MAP={"your-site.netlify.app":"oauth-client-id.apps.googleusercontent.com"}

--- a/src/components/GoogleSignInButton.tsx
+++ b/src/components/GoogleSignInButton.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { GOOGLE_CLIENT_ID } from '../config/googleClient';
+import { resolveGoogleClientId } from '../config/googleClient';
 
 type GsiButtonConfiguration = {
   type?: 'standard' | 'icon';
@@ -80,9 +80,8 @@ export const GoogleSignInButton = ({ onCredential, theme }: GoogleSignInButtonPr
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const clientId = useMemo(() => {
-    const envClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID?.trim() ?? '';
-    const fallbackClientId = (GOOGLE_CLIENT_ID ?? '').trim();
-    return envClientId || fallbackClientId;
+    const hostname = typeof window !== 'undefined' ? window.location.host : undefined;
+    return resolveGoogleClientId(hostname);
   }, []);
 
   useEffect(() => {
@@ -90,8 +89,11 @@ export const GoogleSignInButton = ({ onCredential, theme }: GoogleSignInButtonPr
 
     if (!clientId) {
       setStatus('error');
+      const hostname = typeof window !== 'undefined' ? window.location.host : 'this environment';
       setErrorMessage(
-        'Add a VITE_GOOGLE_CLIENT_ID in your environment or update src/config/googleClient.ts with your client ID to enable Google sign-in.'
+        `No Google client ID configured for ${hostname}. ` +
+          'Add a VITE_GOOGLE_CLIENT_ID environment variable or extend src/config/googleClient.ts with an entry for this host, ' +
+          'and ensure the origin is listed under Authorized JavaScript origins in the Google Cloud Console.'
       );
       return () => {
         isMounted = false;

--- a/src/config/googleClient.ts
+++ b/src/config/googleClient.ts
@@ -1,2 +1,55 @@
-export const GOOGLE_CLIENT_ID = '79775733699-m2t6l70fngeo69s4qjo5pmnoqo8enccm.apps.googleusercontent.com';
+type Hostname = string;
+
+/**
+ * Default client ID that works for the local development environment.
+ * Update the map below or provide environment variables for production
+ * deployments (see README for details).
+ */
+const LOCAL_GOOGLE_CLIENT_ID = '79775733699-m2t6l70fngeo69s4qjo5pmnoqo8enccm.apps.googleusercontent.com';
+
+const FALLBACK_CLIENT_IDS_BY_HOST: Record<Hostname, string> = {
+  /**
+   * Localhost when running `npm run dev`.
+   */
+  'localhost:5173': LOCAL_GOOGLE_CLIENT_ID
+};
+
+const parseHostMapFromEnv = () => {
+  const raw = import.meta.env.VITE_GOOGLE_CLIENT_ID_MAP;
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Record<Hostname, string> | null;
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn(
+      'Unable to parse VITE_GOOGLE_CLIENT_ID_MAP. Provide JSON such as {"your-site.netlify.app":"oauth-client-id"}.',
+      error
+    );
+  }
+
+  return null;
+};
+
+const getHostKey = (hostname?: string) => hostname?.toLowerCase().replace(/^https?:\/\//, '') ?? '';
+
+export const resolveGoogleClientId = (hostname?: string) => {
+  const explicitClientId = (import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '').trim();
+  if (explicitClientId) {
+    return explicitClientId;
+  }
+
+  const mapFromEnv = parseHostMapFromEnv();
+  const combinedMap = mapFromEnv ? { ...FALLBACK_CLIENT_IDS_BY_HOST, ...mapFromEnv } : FALLBACK_CLIENT_IDS_BY_HOST;
+
+  const hostKey = getHostKey(hostname);
+  const clientId = combinedMap[hostKey];
+
+  return clientId?.trim() ?? '';
+};
+
 


### PR DESCRIPTION
## Summary
- resolve the Google client ID from either VITE_GOOGLE_CLIENT_ID or a host-based mapping
- show a clearer error message when no client ID is configured for the current host
- document how to configure production deployments and add environment variable templates for Google sign-in

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e88fe40a40832fb2d0c89a1c90b37b