### PR TITLE
Handle Netlify branch hosts for Google sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm run dev
 When deploying to Netlify (or any other host), create a separate OAuth client ID in the Google Cloud Console and add the deployed domain under **Authorized JavaScript origins**. Then provide the client ID to the app in one of two ways:
 
 - Set a Netlify environment variable named `VITE_GOOGLE_CLIENT_ID` with the production client ID.
-- Or, set `VITE_GOOGLE_CLIENT_ID_MAP` to a JSON object such as `{ "your-site.netlify.app": "oauth-client-id.apps.googleusercontent.com" }` so the app automatically selects the right ID based on `window.location.host`.
+- Or, set `VITE_GOOGLE_CLIENT_ID_MAP` to a JSON object such as `{ "your-site.netlify.app": "oauth-client-id.apps.googleusercontent.com" }` so the app automatically selects the right ID based on `window.location.host`. Branch deploys on Netlify (for example, `feature-123--your-site.netlify.app`) automatically fall back to the production host entry.
 
 Without this configuration Google will respond with an `origin_mismatch` error when users try to sign in from the deployed site.
 


### PR DESCRIPTION
## Summary
- add host candidate derivation so Netlify branch deploys reuse the production Google client ID
- document that Netlify branch deploys will fall back to the base host entry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e89347d9bc832fa9a2d6146c8959e6