### PR TITLE
Normalize host matching for Google sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm run dev
 When deploying to Netlify (or any other host), create a separate OAuth client ID in the Google Cloud Console and add the deployed domain under **Authorized JavaScript origins**. Then provide the client ID to the app in one of two ways:
 
 - Set a Netlify environment variable named `VITE_GOOGLE_CLIENT_ID` with the production client ID.
-- Or, set `VITE_GOOGLE_CLIENT_ID_MAP` to a JSON object such as `{ "your-site.netlify.app": "oauth-client-id.apps.googleusercontent.com" }` so the app automatically selects the right ID based on `window.location.host`.
+- Or, set `VITE_GOOGLE_CLIENT_ID_MAP` to a JSON object such as `{ "your-site.netlify.app": "oauth-client-id.apps.googleusercontent.com" }` so the app automatically selects the right ID based on `window.location.host`. Keys can include the bare hostname, host:port, or even the full origin (for example, `https://your-site.netlify.app`). Branch deploys on Netlify (for example, `feature-123--your-site.netlify.app`) automatically fall back to the production host entry.
 
 Without this configuration Google will respond with an `origin_mismatch` error when users try to sign in from the deployed site.
 

--- a/src/config/googleClient.ts
+++ b/src/config/googleClient.ts
@@ -7,12 +7,49 @@ type Hostname = string;
  */
 const LOCAL_GOOGLE_CLIENT_ID = '79775733699-m2t6l70fngeo69s4qjo5pmnoqo8enccm.apps.googleusercontent.com';
 
-const FALLBACK_CLIENT_IDS_BY_HOST: Record<Hostname, string> = {
+const getHostKey = (hostname?: string) => hostname?.toLowerCase().replace(/^https?:\/\//, '') ?? '';
+
+const stripPort = (hostname?: string) => hostname?.replace(/:\d+$/, '') ?? '';
+
+const normalizeHostMapKeys = (map: Record<Hostname, string>) => {
+  const normalized: Record<Hostname, string> = {};
+
+  Object.entries(map).forEach(([rawKey, rawValue]) => {
+    if (typeof rawValue !== 'string') {
+      return;
+    }
+
+    const value = rawValue.trim();
+    if (!value) {
+      return;
+    }
+
+    const trimmedKey = rawKey.trim();
+    if (!trimmedKey) {
+      return;
+    }
+
+    const hostWithPort = getHostKey(trimmedKey);
+    const hostWithoutPort = stripPort(hostWithPort);
+
+    if (hostWithPort) {
+      normalized[hostWithPort] = value;
+    }
+
+    if (hostWithoutPort) {
+      normalized[hostWithoutPort] = value;
+    }
+  });
+
+  return normalized;
+};
+
+const FALLBACK_CLIENT_IDS_BY_HOST = normalizeHostMapKeys({
   /**
    * Localhost when running `npm run dev`.
    */
   'localhost:5173': LOCAL_GOOGLE_CLIENT_ID
-};
+});
 
 const parseHostMapFromEnv = () => {
   const raw = import.meta.env.VITE_GOOGLE_CLIENT_ID_MAP;
@@ -23,7 +60,7 @@ const parseHostMapFromEnv = () => {
   try {
     const parsed = JSON.parse(raw) as Record<Hostname, string> | null;
     if (parsed && typeof parsed === 'object') {
-      return parsed;
+      return normalizeHostMapKeys(parsed);
     }
   } catch (error) {
     console.warn(
@@ -35,7 +72,51 @@ const parseHostMapFromEnv = () => {
   return null;
 };
 
-const getHostKey = (hostname?: string) => hostname?.toLowerCase().replace(/^https?:\/\//, '') ?? '';
+const deriveHostCandidates = (hostname?: string): string[] => {
+  const hostKey = stripPort(getHostKey(hostname));
+
+  if (!hostKey) {
+    return [];
+  }
+
+  const candidates = new Set<string>([
+    hostKey,
+    getHostKey(hostname),
+    hostname ?? '',
+    stripPort(hostname)
+  ]);
+
+  const addProtocolVariants = (baseHost: string) => {
+    if (!baseHost) {
+      return;
+    }
+
+    candidates.add(`https://${baseHost}`);
+    candidates.add(`https://${baseHost}/`);
+    candidates.add(`http://${baseHost}`);
+    candidates.add(`http://${baseHost}/`);
+  };
+
+  addProtocolVariants(hostKey);
+
+  const netlifyBranchMatch = hostKey.match(/^.+?--(.+\.netlify\.app)$/);
+  if (netlifyBranchMatch) {
+    const baseHost = netlifyBranchMatch[1];
+    candidates.add(baseHost);
+    addProtocolVariants(baseHost);
+  }
+
+  const labels = hostKey.split('.');
+  for (let i = 1; i < labels.length - 1; i += 1) {
+    const candidate = labels.slice(i).join('.');
+    if (candidate) {
+      candidates.add(candidate);
+      addProtocolVariants(candidate);
+    }
+  }
+
+  return Array.from(candidates).filter(Boolean);
+};
 
 export const resolveGoogleClientId = (hostname?: string) => {
   const explicitClientId = (import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '').trim();
@@ -44,10 +125,12 @@ export const resolveGoogleClientId = (hostname?: string) => {
   }
 
   const mapFromEnv = parseHostMapFromEnv();
-  const combinedMap = mapFromEnv ? { ...FALLBACK_CLIENT_IDS_BY_HOST, ...mapFromEnv } : FALLBACK_CLIENT_IDS_BY_HOST;
+  const combinedMap = mapFromEnv
+    ? { ...FALLBACK_CLIENT_IDS_BY_HOST, ...normalizeHostMapKeys(mapFromEnv) }
+    : FALLBACK_CLIENT_IDS_BY_HOST;
 
-  const hostKey = getHostKey(hostname);
-  const clientId = combinedMap[hostKey];
+  const hostCandidates = deriveHostCandidates(hostname);
+  const clientId = hostCandidates.map((candidate) => combinedMap[candidate]).find((value) => Boolean(value));
 
   return clientId?.trim() ?? '';
 };


### PR DESCRIPTION
## Summary
- normalize configured host keys so Google client IDs match host, host:port, or origin entries
- expand runtime host candidates to cover protocol-prefixed and Netlify branch variants when resolving the client ID
- document the accepted host key formats for VITE_GOOGLE_CLIENT_ID_MAP

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e89347d9bc832fa9a2d6146c8959e6