### PR TITLE
Fix income sign handling and title case labels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ const baseCategories: Category[] = [
   },
   {
     id: 'financial-obligations',
-    name: 'Financial obligations',
+    name: 'Financial Obligations',
     accent: '#93c5fd',
     description: 'Mortgages, rent, insurance and the must-pay bills that keep life stable.',
     transactions: [
@@ -150,7 +150,7 @@ const baseCategories: Category[] = [
   },
   {
     id: 'savings-investments',
-    name: 'Savings & investments',
+    name: 'Savings & Investments',
     accent: '#a5f3fc',
     description: 'Long-term wins such as emergency funds, retirement and brokerage deposits.',
     transactions: [
@@ -326,10 +326,10 @@ export default function App() {
   const navigationItems = useMemo(
     () => [
       { id: 'monthly-overview', label: 'Monthly' },
-      { id: 'log-transaction', label: 'Log a transaction' },
+      { id: 'log-transaction', label: 'Log a Transaction' },
       { id: 'categories-section', label: 'Categories' },
       { id: 'pinned-transactions', label: 'Pinned' },
-      { id: 'insights-section', label: 'Budget & expenses' },
+      { id: 'insights-section', label: 'Budget & Expenses' },
       { id: 'yearly-outlook', label: 'Yearly' }
     ],
     []
@@ -454,11 +454,12 @@ export default function App() {
     categories.forEach((category) => {
       totals[category.id] = category.transactions.reduce((sum, transaction) => {
         const normalized = transaction.amount * cadenceToMonthlyFactor[transaction.cadence];
+
         if (transaction.flow === 'Income') {
-          return sum - normalized;
+          return sum + normalized;
         }
 
-        return sum + normalized;
+        return sum - normalized;
       }, 0);
     });
 
@@ -491,14 +492,14 @@ export default function App() {
 
     const topCategory = categories.reduce<{ name: string; total: number }>(
       (acc, category) => {
-        const total = categoryMonthlyTotals[category.id];
+        const total = Math.abs(categoryMonthlyTotals[category.id]);
         if (total > acc.total) {
           return { name: category.name, total };
         }
 
         return acc;
       },
-      { name: categories[0]?.name ?? 'Financial obligations', total: 0 }
+      { name: categories[0]?.name ?? 'Financial Obligations', total: 0 }
     );
 
     return {
@@ -788,7 +789,7 @@ export default function App() {
 
   const { monthlyExpenses, monthlySavings, monthlyIncome, net } = summary;
   const hasMonthlyLeftover = net >= 0;
-  const netLabel = hasMonthlyLeftover ? 'Left after bills' : 'Short this month';
+  const netLabel = hasMonthlyLeftover ? 'Left After Bills' : 'Short This Month';
   const netNote = hasMonthlyLeftover
     ? 'Use this for goals or flexible spending'
     : 'Plan to cover this gap soon';
@@ -913,13 +914,16 @@ export default function App() {
 
     const spendingBars: InsightBar[] = categories
       .filter((category) => category.id !== 'income')
-      .map((category) => ({
-        id: category.id,
-        name: category.name,
-        monthlyValue: categoryMonthlyTotals[category.id],
-        value: categoryMonthlyTotals[category.id] * sanitizedInsightTimeframe,
-        accent: category.accent
-      }))
+      .map((category) => {
+        const monthlyValue = Math.abs(categoryMonthlyTotals[category.id]);
+        return {
+          id: category.id,
+          name: category.name,
+          monthlyValue,
+          value: monthlyValue * sanitizedInsightTimeframe,
+          accent: category.accent
+        };
+      })
       .filter((bar) => bar.value > 0);
 
     const spendingTotal = spendingBars.reduce((sum, bar) => sum + bar.value, 0);
@@ -937,45 +941,45 @@ export default function App() {
 
     const allocationBars: InsightBar[] = [];
 
-    if (livingCosts > 0) {
-      allocationBars.push({
-        id: 'living-costs',
-        name: 'Living costs & essentials',
-        monthlyValue: livingCostsMonthly,
-        value: livingCosts,
-        accent: '#93c5fd'
-      });
-    }
+      if (livingCosts > 0) {
+        allocationBars.push({
+          id: 'living-costs',
+          name: 'Living Costs & Essentials',
+          monthlyValue: livingCostsMonthly,
+          value: livingCosts,
+          accent: '#93c5fd'
+        });
+      }
 
-    if (savings > 0) {
-      allocationBars.push({
-        id: 'savings',
-        name: 'Savings & investments',
-        monthlyValue: savingsMonthly,
-        value: savings,
-        accent: '#99f6e4'
-      });
-    }
+      if (savings > 0) {
+        allocationBars.push({
+          id: 'savings',
+          name: 'Savings & Investments',
+          monthlyValue: savingsMonthly,
+          value: savings,
+          accent: '#99f6e4'
+        });
+      }
 
-    if (available > 0) {
-      allocationBars.push({
-        id: 'available',
-        name: 'Available to assign',
-        monthlyValue: availableMonthly,
-        value: available,
-        accent: '#bbf7d0'
-      });
-    }
+      if (available > 0) {
+        allocationBars.push({
+          id: 'available',
+          name: 'Available to Assign',
+          monthlyValue: availableMonthly,
+          value: available,
+          accent: '#bbf7d0'
+        });
+      }
 
-    if (overBudget > 0) {
-      allocationBars.push({
-        id: 'over-budget',
-        name: 'Over budget',
-        monthlyValue: overBudgetMonthly,
-        value: overBudget,
-        accent: '#fbcfe8'
-      });
-    }
+      if (overBudget > 0) {
+        allocationBars.push({
+          id: 'over-budget',
+          name: 'Over Budget',
+          monthlyValue: overBudgetMonthly,
+          value: overBudget,
+          accent: '#fbcfe8'
+        });
+      }
 
     const allocationTotal = allocationBars.reduce((sum, bar) => sum + bar.value, 0);
     const hasAvailable = availableMonthly > 0;
@@ -992,7 +996,7 @@ export default function App() {
       allocation: {
         bars: allocationBars,
         total: allocationTotal,
-        summaryLabel: hasAvailable ? 'Budget allocation' : 'Budget pressure',
+        summaryLabel: hasAvailable ? 'Budget Allocation' : 'Budget Pressure',
         summaryHelper: hasAvailable
           ? `How your income covers ${timeframeSentence}.`
           : `Where expenses exceed income over ${timeframeSentence}.`,
@@ -1130,11 +1134,12 @@ export default function App() {
 
       const monthlyTotal = scopedTransactions.reduce((sum, transaction) => {
         const normalized = transaction.amount * cadenceToMonthlyFactor[transaction.cadence];
+
         if (transaction.flow === 'Income') {
-          return sum - normalized;
+          return sum + normalized;
         }
 
-        return sum + normalized;
+        return sum - normalized;
       }, 0);
 
       return {
@@ -1535,7 +1540,7 @@ export default function App() {
         <section id="monthly-overview" className="summary-card" tabIndex={-1}>
           <div className="summary-header">
             <div className="summary-intro">
-              <h2>Monthly summary</h2>
+              <h2>Monthly Summary</h2>
               <p>
                 See {monthLabel} {selectedYear} at a glance. Pick a month now and syncing will kick in
                 when Google sign-in and the database launch.
@@ -1572,19 +1577,19 @@ export default function App() {
           </div>
           <div className="summary-grid">
             <div className="stat">
-              <span className="stat-label">Money coming in</span>
+              <span className="stat-label">Money Coming In</span>
               <span className="stat-value">{formatCurrency(monthlyIncome)}</span>
-              <span className="stat-note">Average monthly income</span>
+              <span className="stat-note">Average Monthly Income</span>
             </div>
             <div className="stat">
-              <span className="stat-label">Money going out</span>
+              <span className="stat-label">Money Going Out</span>
               <span className="stat-value">{formatCurrency(monthlyExpenses)}</span>
-              <span className="stat-note">Bills, plans, and recurring costs</span>
+              <span className="stat-note">Bills, Plans, and Recurring Costs</span>
             </div>
             <div className="stat">
-              <span className="stat-label">Set aside for savings</span>
+              <span className="stat-label">Set Aside for Savings</span>
               <span className="stat-value">{formatCurrency(monthlySavings)}</span>
-              <span className="stat-note">What you’re tucking away every month</span>
+              <span className="stat-note">What You’re Tucking Away Every Month</span>
             </div>
             <div className="stat">
               <span className="stat-label">{netLabel}</span>
@@ -1607,7 +1612,7 @@ export default function App() {
         >
           <div className="section-heading">
             <div>
-              <h2>Categories & transactions</h2>
+              <h2>Categories & Transactions</h2>
               <p>Review recent activity, tidy each lane, and pin anything you want to watch.</p>
             </div>
             <div className="section-heading__actions">
@@ -1703,7 +1708,7 @@ export default function App() {
           <div className="pinned-card">
             <div className="pinned-header">
               <div className="pinned-header__intro">
-                <h2>Pinned transactions</h2>
+                <h2>Pinned Transactions</h2>
                 <p>Pin a transaction above to keep it handy. Syncing will follow once sign-in ships.</p>
                 <span className="pinned-header__note">
                   Showing totals per <strong>{pinnedCadenceDisplay[pinnedViewCadence]}</strong>.
@@ -1786,7 +1791,7 @@ export default function App() {
       <section id="insights-section" className="section-block insights-section" tabIndex={-1}>
         <div className="section-heading">
           <div>
-            <h2>Insight spotlight</h2>
+            <h2>Insight Spotlight</h2>
             <p>Glance at the categories shaping your month and how income is working for you.</p>
           </div>
         </div>
@@ -1794,7 +1799,7 @@ export default function App() {
           <article className="insight-card insight-card--spending">
             <div className="insight-header">
               <span className="insight-kicker">Spending palette</span>
-              <h2>Expenses by category</h2>
+              <h2>Expenses by Category</h2>
               <p>Hover or tap to see which categories drive this window of spending.</p>
             </div>
             <div className="insight-controls">
@@ -1874,7 +1879,7 @@ export default function App() {
           <article className="insight-card insight-card--allocation">
             <div className="insight-header">
               <span className="insight-kicker">Budget pulse</span>
-              <h2>How income is split</h2>
+              <h2>How Income Is Split</h2>
               <p>See how your income covers costs, savings, and wiggle room for this timeframe.</p>
             </div>
             <div className="insight-controls">
@@ -2086,7 +2091,7 @@ export default function App() {
         <div className="yearly-card">
           <div className="yearly-header">
             <div className="yearly-intro">
-              <h2>Yearly breakdown</h2>
+              <h2>Yearly Breakdown</h2>
               <p>
                 Glance at {selectedYear} totals. Pick any year now and syncing will take over once
                 sign-in launches.
@@ -2120,15 +2125,15 @@ export default function App() {
           </div>
           <div className="yearly-grid">
             <div className="yearly-stat">
-              <span className="yearly-label">Yearly income</span>
+              <span className="yearly-label">Yearly Income</span>
               <span className="yearly-value">{formatCurrency(yearlyOutlook.income)}</span>
             </div>
             <div className="yearly-stat">
-              <span className="yearly-label">Yearly bills & plans</span>
+              <span className="yearly-label">Yearly Bills & Plans</span>
               <span className="yearly-value">{formatCurrency(yearlyOutlook.expenses)}</span>
             </div>
             <div className="yearly-stat">
-              <span className="yearly-label">Saved across the year</span>
+              <span className="yearly-label">Saved Across the Year</span>
               <span className="yearly-value">{formatCurrency(yearlyOutlook.savings)}</span>
             </div>
             <div className="yearly-stat">

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -88,7 +88,7 @@ export function TransactionForm({ id, categories, onAddTransaction }: Transactio
   return (
     <form id={id} className="form-card" onSubmit={handleSubmit} tabIndex={-1}>
       <div>
-        <h2>Log a transaction</h2>
+        <h2>Log a Transaction</h2>
         <p className="helper-text">
           Quickly capture a change: name it, date it, choose the lane, and you’re done.
         </p>
@@ -195,7 +195,7 @@ export function TransactionForm({ id, categories, onAddTransaction }: Transactio
       </div>
 
       <button type="submit" className="add-button">
-        Add transaction
+        Add Transaction
       </button>
     </form>
   );


### PR DESCRIPTION
## Summary
- ensure income totals aggregate as positive inflows while expenses and savings reduce category totals
- update insights to treat spending bars as absolute values so visualizations remain correct
- convert navigation, headings, and allocation labels to title case, including the transaction form copy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ef013550dc832fad25646cce1e41f2